### PR TITLE
Support for `as_json` ( non-primitave rails values )

### DIFF
--- a/lib/jsondiff.rb
+++ b/lib/jsondiff.rb
@@ -4,6 +4,8 @@ require 'jsondiff/array_diff'
 
 module JsonDiff
   include Helpers
+  
+  PRIMATIVES = [String,Array,Hash,NilClass,TrueClass,FalseClass,Integer,Float,Fixnum]
 
   # Generate a patch from two ruby hash
   #
@@ -16,6 +18,8 @@ module JsonDiff
       HashDiff.generate(result, prefix, arg1, arg2)
     elsif Array === arg1 && Array === arg2
       ArrayDiff.generate(result, prefix, arg1, arg2)
+    elsif not PRIMATIVES.include?(arg2.class) and arg2.respond_to?(:as_json) and arg2.as_json.class != arg2.class
+      self.generate(arg1.as_json, arg2.as_json, result, prefix)
     else
       result << replace_op(prefix, arg2)
     end


### PR DESCRIPTION
Allowed for support ( optomized and graceful ) for the fact that `as_json` sometimes needs to be called on an object to get its primitive equivelent.

So a change like:

```
# So a change like
'NilClass' -->'ActiveSupport::TimeWithZone'
# Will now be processed as:
'NilClass'--> 'String'
```
